### PR TITLE
Exclude libssl and libcrypto from PyInstaller bundle

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -73,7 +73,7 @@ a = Analysis(
     noarchive=False,
 )
 
-excluded_libs = ['libstdc++.so', 'iris_dri.so', 'swrast_dri.so']
+excluded_libs = ['libstdc++.so', 'iris_dri.so', 'swrast_dri.so', 'libssl.so', 'libcrypto.so']
 a.binaries = [(pkg, src, typ) for pkg, src, typ in a.binaries
               if not any(lib in src for lib in excluded_libs)]
 


### PR DESCRIPTION
## Description
This pull request updates the PyInstaller spec file to exclude `libssl` and `libcrypto` from the bundled application. The exclusion of these libraries addresses potential conflicts that can arise when the bundled application is run on systems with different versions of these libraries installed.

## **Key Changes:**
Modified the `./build.spec` file to add `libssl` and `libcrypto` to the `excluded_libs` list. This ensures that these libraries are not included in the final executable, allowing the system's version of these libraries to be used instead. 

```
line 76  -  excluded_libs = ['libstdc++.so', 'iris_dri.so', 'swrast_dri.so']
line 76  +  excluded_libs = ['libstdc++.so', 'iris_dri.so', 'swrast_dri.so', 'libssl.so', 'libcrypto.so']
```

## **Testing:**
- The application was tested on Ubuntu 22.04.4 LTS platforms.
- The application was tested on EndeavourOS platforms as of 07/05/2024.